### PR TITLE
Time compatible with Hashable

### DIFF
--- a/Sources/SwiftSubtitles/Subtitles+time.swift
+++ b/Sources/SwiftSubtitles/Subtitles+time.swift
@@ -28,7 +28,7 @@ import Foundation
 
 public extension Subtitles {
 	/// A time definition for a subtitles file
-	struct Time: Equatable, Comparable, Codable {
+	struct Time: Hashable, Comparable, Codable {
 		/// Create a Time
 		public init(hour: UInt = 0, minute: UInt = 0, second: UInt = 0, millisecond: UInt = 0) {
 			self.hour = hour


### PR DESCRIPTION
That could have compatibility with Hashable.
In SwiftUI, Time object might be useful for the list's identifier. but Equatable is not enough.

```swift
ForEach(cues, \.startTime) { cue in ... }
```

I appreciate your great work.