### PR TITLE
include iOS/tvOS 12 as supported versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
 	name: "SwiftSubtitles",
 	platforms: [
 		.macOS(.v10_13),
-		.iOS(.v13),
-		.tvOS(.v13),
+		.iOS(.v12),
+		.tvOS(.v12),
 		.watchOS(.v4)
 	],
 	products: [


### PR DESCRIPTION
I would like to use **SwiftSubtitles** as a dependency in a project that has iOS/tvOS 12 as minimum supported version in its target.

The aim of this PR is simply to change the version value in the SPM package manifest file.

I have already tested the compatibility of the source files when building for a target with v12 support.
The source files of **SwiftSubtitles** (including its dependencies **DSFRegex** and **TinyCSV**) compile gracefully when added as compilation sources to a target with minimum version 12.

I see that in [this specific commit](https://github.com/dagronf/SwiftSubtitles/commit/09f49dfe7b28481755866df856294f09a929addc) it was explicitly coded that the minimum supported version is set to 13. Was there a specific reason for this? If not then please consider changing this value to what the PR suggests.