### PR TITLE
add podspec file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
 		.macOS(.v10_13),
 		.iOS(.v13),
 		.tvOS(.v13),
-		.watchOS(.v4)
+		.watchOS(.v6)
 	],
 	products: [
 		.library(

--- a/SwiftSubtitles.podspec
+++ b/SwiftSubtitles.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.author               = { "Darren Ford" => "dford_au-reg@yahoo.com" }
   s.source               = { :git => "https://github.com/dagronf/SwiftSubtitles.git", :tag => s.version.to_s }
   s.source_files         = 'Sources/SwiftSubtitles/**/*.swift'
-  s.platforms            = { :ios => "12.0", :tvos => "12.0", :osx => "10.13", :watchos => "4.0" }
+  s.platforms            = { :ios => "12.0", :tvos => "12.0", :osx => "10.13", :watchos => "6.0" }
   s.swift_versions       = ['5.4', '5.5', '5.6', '5.7']
   s.dependency           'DSFRegex', '~> 3.1.0'
   s.dependency           'TinyCSV', '~> 0.5.1'

--- a/SwiftSubtitles.podspec
+++ b/SwiftSubtitles.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name                 = "SwiftSubtitles"
+  s.version              = "0.8.1"
+  s.summary              = "A Swift package for reading/writing some common subtitle formats."
+  s.description          = <<-DESC
+    A Swift package for reading/writing subtitle formats (srt, sbv, sub, vtt, csv).
+  DESC
+  s.homepage             = "https://github.com/dagronf"
+  s.license              = { :type => "MIT", :file => "LICENSE" }
+  s.author               = { "Darren Ford" => "dford_au-reg@yahoo.com" }
+  s.source               = { :git => "https://github.com/dagronf/SwiftSubtitles.git", :tag => s.version.to_s }
+  s.source_files         = 'Sources/SwiftSubtitles/**/*.swift'
+  s.platforms            = { :ios => "12.0", :tvos => "12.0", :osx => "10.13", :watchos => "4.0" }
+  s.swift_versions       = ['5.4', '5.5', '5.6', '5.7']
+  s.dependency           'DSFRegex', '~> 3.1.0'
+  s.dependency           'TinyCSV', '~> 0.5.1'
+end


### PR DESCRIPTION
Adding podspec file to publish **SwiftSubtitles** on Cocoapods dependency manager.
This process will release the module on the Cocoapods public spec repo.

This will release the latest version of **SwiftSubtitles** which is 0.8.1

This pod has dependencies on **DSFRegex** and **TinyCSV** which also need to be published on Cocoapods.
I will open separate pull requests for the dependency modules above.

Validation will not pass until those dependencies are made available.
Validating with command: `pod spec lint SwiftSubtitles.podspec --verbose` at the root of the project directory.