### PR TITLE
Fix carriage return / line feed newlines

### DIFF
--- a/Sources/SwiftSubtitles/String+subtitles.swift
+++ b/Sources/SwiftSubtitles/String+subtitles.swift
@@ -1,0 +1,39 @@
+//
+//  String+subtitles.swift
+//
+//  Copyright © 2023 Darren Ford. All rights reserved.
+//
+//  MIT License
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+
+import Foundation
+
+extension String {
+    var lines: [String] {
+        var linesArray = [String]()
+        // Split the string into lines using any type of newline (CR, LF, or CRLF)
+        enumerateLines { line, _ in
+            linesArray.append(line)
+        }
+        return linesArray
+    }
+}

--- a/Sources/SwiftSubtitles/coding/SBV.swift
+++ b/Sources/SwiftSubtitles/coding/SBV.swift
@@ -104,7 +104,7 @@ public extension Subtitles.Coder.SBV {
 	func decode(_ content: String) throws -> Subtitles {
 		var results = [Subtitles.Cue]()
 
-		let lines = content.components(separatedBy: .newlines)
+		let lines = content.lines
 
 		var position: Int = 1
 

--- a/Sources/SwiftSubtitles/coding/SRT.swift
+++ b/Sources/SwiftSubtitles/coding/SRT.swift
@@ -118,7 +118,7 @@ public extension Subtitles.Coder.SRT {
 
 		var results = [Subtitles.Cue]()
 
-		let lines = content.components(separatedBy: .newlines)
+		let lines = content.lines
 
 		var currentState: LineState = .blank
 

--- a/Sources/SwiftSubtitles/coding/SUB.swift
+++ b/Sources/SwiftSubtitles/coding/SUB.swift
@@ -89,7 +89,7 @@ public extension Subtitles.Coder.SUB {
 	/// - Returns: Subtitles
 	func decode(_ content: String) throws -> Subtitles {
 		var results = [Subtitles.Cue]()
-		let lines = content.components(separatedBy: .newlines)
+		let lines = content.lines
 
 		/// {0}{25}{y:i}Hello!|{y:b}How are you?
 

--- a/Sources/SwiftSubtitles/coding/VTT.swift
+++ b/Sources/SwiftSubtitles/coding/VTT.swift
@@ -103,7 +103,7 @@ public extension Subtitles.Coder.VTT {
 	/// - Returns: Subtitles
 	func decode(_ content: String) throws -> Subtitles {
 		let lines = content
-			.components(separatedBy: .newlines)
+			.lines
 			.enumerated()
 			.map { (offset: $0.offset, element: $0.element.trimmingCharacters(in: .whitespaces)) }
 

--- a/Tests/SwiftSubtitlesTests/CommonTests.swift
+++ b/Tests/SwiftSubtitlesTests/CommonTests.swift
@@ -235,4 +235,14 @@ other lending institution
 			XCTAssertNil(ss.cueType(for: 16))
 		}
 	}
+    
+    func testStringLines() throws {
+        let crLfString = "WEBVTT\r\n\r\n00:00:05.312 --> 00:00:06.729 line:90%,end position:50%,center align:center\r\nIt’s 9:00 a.m.\r\n\r\n00:00:06.729 --> 00:00:08.687 line:90%,end position:50%,center align:center\r\non a Tuesday morning"
+        let nlString = "WEBVTT\n\n00:00:05.312 --> 00:00:06.729 line:90%,end position:50%,center align:center\nIt’s 9:00 a.m.\n\n00:00:06.729 --> 00:00:08.687 line:90%,end position:50%,center align:center\non a Tuesday morning"
+        let crLFLines = crLfString.lines
+        let nlLines = nlString.lines
+
+        XCTAssertEqual(crLFLines, nlLines)
+        XCTAssertEqual(crLFLines.count, 7)
+    }
 }


### PR DESCRIPTION
Hi,
I recently tried your package with some .VTT files that had `\r\n`. When decoding I'd get a `unexpectedEndOfCue` error. When debugging I found that the `sections` array would contain only 1-element elements:
```
(lldb) p sections
([[(index: Int, line: String)]]) $R0 = 188 values {
  [0] = 1 value {
    [0] = (index = 0, line = "WEBVTT")
  }
  [1] = 1 value {
    [0] = (index = 4, line = "00:00:05.855 --> 00:00:09.105 line:90%,end position:50%,center align:center")
  }
  [2] = 1 value {
    [0] = (index = 6, line = "It’s 9:00 a.m.")
  }
```

Turns out that `components(separatedBy: .newlines)`  counts `\r\n` separately, which makes sense, I guess..? However, I fixed it by writing a String extension using `enumerateLines(_ block:)`, which seemed like the cleanest and nicest solution to me. 
Lmk what you think :)

# See Also
- [How to split a string with newlines - StackOverflow](https://stackoverflow.com/questions/15156406/how-to-split-a-string-with-newlines/32062956#32062956)