### PR TITLE
Support multiple decimal formats in WebVTT parser

### DIFF
--- a/Sources/SwiftSubtitles/coding/VTT.swift
+++ b/Sources/SwiftSubtitles/coding/VTT.swift
@@ -40,7 +40,7 @@ extension Subtitles.Coder {
 }
 
 /// The time matching regex
-private let VTTTimeRegex__ = try! DSFRegex(#"(?:(\d*):)?(?:(\d*):)(\d*)\.(\d{3})\s-->\s(?:(\d*):)?(?:(\d*):)(\d*)\.(\d{3})"#)
+private let VTTTimeRegex__ = try! DSFRegex(#"(?:(\d*):)?(?:(\d*):)(\d*)[.,](\d{3})\s*-->\s*(?:(\d*):)?(?:(\d*):)(\d*)[.,](\d{3})"#)
 
 public extension Subtitles.Coder.VTT {
 	/// Encode subtitles as Data

--- a/Tests/SwiftSubtitlesTests/VTTTests.swift
+++ b/Tests/SwiftSubtitlesTests/VTTTests.swift
@@ -238,4 +238,60 @@ Language: en
 		XCTAssertEqual(subtitles.cues[1].text, "2nd subtitle.")
 	}
 
+    func testCommaDecimalHandling() throws {
+        let contentWithCommas = """
+WEBVTT
+
+00:00:01,000 --> 00:00:04,000
+Never drink liquid nitrogen.
+"""
+
+        let coder = Subtitles.Coder.VTT()
+        let subtitlesWithCommas = try coder.decode(contentWithCommas)
+
+        XCTAssertEqual(subtitlesWithCommas.cues[0].startTime, Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0))
+        XCTAssertEqual(subtitlesWithCommas.cues[0].endTime, Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0))
+    }
+
+    func testDotDecimalHandling() throws {
+        let contentWithDots = """
+WEBVTT
+
+00:00:01.000 --> 00:00:04.000
+Never drink liquid nitrogen.
+"""
+
+        let coder = Subtitles.Coder.VTT()
+        let subtitlesWithDots = try coder.decode(contentWithDots)
+
+        XCTAssertEqual(subtitlesWithDots.cues[0].startTime, Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0))
+        XCTAssertEqual(subtitlesWithDots.cues[0].endTime, Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0))
+    }
+
+    func testSpaceHandling() throws {
+        // Test with spaces around '-->'
+        let contentWithSpaces = """
+WEBVTT
+
+00:00:01.000  -->  00:00:04.000
+Never drink liquid nitrogen.
+"""
+        let coder = Subtitles.Coder.VTT()
+        var subtitles = try coder.decode(contentWithSpaces)
+
+        XCTAssertEqual(subtitles.cues[0].startTime, Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0))
+        XCTAssertEqual(subtitles.cues[0].endTime, Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0))
+
+        // Test without spaces around '-->'
+        let contentWithoutSpaces = """
+WEBVTT
+
+00:00:01.000-->00:00:04.000
+Never drink liquid nitrogen.
+"""
+        subtitles = try coder.decode(contentWithoutSpaces)
+
+        XCTAssertEqual(subtitles.cues[0].startTime, Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0))
+        XCTAssertEqual(subtitles.cues[0].endTime, Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0))
+    }
 }


### PR DESCRIPTION
This commit introduces the following enhancements to the WebVTT parser:

1. Support for both dot and comma as decimal separators.
2. Flexibility to handle arbitrary spaces around the "-->" delimiter.

Unit tests have been added to verify the changes and catch regressions.

During my work, I encountered WebVTT files that used the comma decimal system. This was specifically because the software creator, who is based in Germany, implemented OpenAI's Whisper engine. This experience highlighted the need for this feature. The comma as a decimal separator is also widely adopted in various countries, particularly in Europe and South America.

I appreciate the versatility of this project, especially its capability to read multiple subtitle formats. It's helpful for testing a new concept, and I'm pleased to contribute back.