### PR TITLE
Support for podcast index json format

### DIFF
--- a/Demos/Subtitle Viewer/Subtitle Viewer/DocumentController.swift
+++ b/Demos/Subtitle Viewer/Subtitle Viewer/DocumentController.swift
@@ -33,7 +33,7 @@ class DocumentController: NSDocumentController {
 		openPanel.allowsMultipleSelection = false
 		openPanel.canChooseFiles = true
 		openPanel.canChooseDirectories = false
-		openPanel.allowedFileTypes = ["srt", "sub", "vtt", "sbv", "csv"]
+		openPanel.allowedFileTypes = ["srt", "sub", "vtt", "sbv", "csv", "json"]
 
 		openPanel.accessoryView = a.view
 		openPanel.delegate = openAccessory

--- a/Demos/Subtitle Viewer/Subtitle Viewer/Info.plist
+++ b/Demos/Subtitle Viewer/Subtitle Viewer/Info.plist
@@ -6,6 +6,20 @@
 	<array>
 		<dict>
 			<key>CFBundleTypeName</key>
+			<string>JSON subtitle file</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.json</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).Document</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
 			<string>WebVTT subtitle file</string>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
@@ -169,6 +183,25 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>sub</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>PodcastIndex JSON subtitle file</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>public.json</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>json</string>
 				</array>
 			</dict>
 		</dict>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Swift package for reading/writing some common subtitle formats.
 | SRT (SubRip)     | `Subtitles.Coder.SRT`  | `.srt`          |
 | VTT (WebVTT)     | `Subtitles.Coder.VTT`  | `.vtt`          |
 | CSV              | `Subtitles.Coder.CSV`  | `.csv`          |
+| JSON (Podcast Index) | `Subtitles.Coder.JSONPodcastsIndex | `.json` |
 
 * Read-only
 

--- a/Sources/SwiftSubtitles/Subtitles+codable.swift
+++ b/Sources/SwiftSubtitles/Subtitles+codable.swift
@@ -113,5 +113,6 @@ extension Subtitles.Coder {
 		Subtitles.Coder.JSON.self,
 		Subtitles.Coder.SUB.self,
 		Subtitles.Coder.CSV.self,
+        Subtitles.Coder.JSONPodcastIndex.self,
 	]
 }

--- a/Sources/SwiftSubtitles/coding/JSONPodcastIndex.swift
+++ b/Sources/SwiftSubtitles/coding/JSONPodcastIndex.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+extension Subtitles.Coder {
+    /// A JSON coder
+    public struct JSONPodcastIndex: SubtitlesCodable, SubtitlesTextCodable, Codable {
+        public static var extn: String { "json" }
+        public static func Create() -> Self { JSONPodcastIndex() }
+        public init() { 
+            version = "1.0.0"
+            segments = []
+        }
+
+        public init(version: String, segments: [Segment]) {
+            self.version = version
+            self.segments = segments
+        }
+
+        public struct Segment: Codable {
+            let speaker: String?
+            let startTime: Double
+            let endTime: Double
+            let body: String
+        }
+
+        let version: String
+        let segments: [Segment]
+    }
+}
+
+public extension Subtitles.Coder.JSONPodcastIndex {
+    /// Encode subtitles as Data
+    /// - Parameters:
+    ///   - subtitles: The subtitles to encode
+    ///   - encoding: The encoding to use if the content is text
+    /// - Returns: The encoded Data
+    func encode(subtitles: Subtitles, encoding: String.Encoding) throws -> Data {
+        var segments = [Segment]()
+        for cue in subtitles.cues {
+            let segment = Segment(speaker: "", startTime: cue.startTimeInSeconds, endTime: cue.endTimeInSeconds, body: cue.text)
+            segments.append(segment)
+        }
+        return try JSONEncoder().encode(Subtitles.Coder.JSONPodcastIndex(version: "1.0.0", segments: segments))
+    }
+
+    /// Encode subtitles as a String
+    /// - Parameters:
+    ///   - subtitles: The subtitles to encode
+    /// - Returns: The encoded String
+    func encode(subtitles: Subtitles) throws -> String {
+        let data = try self.encode(subtitles: subtitles, encoding: .utf8)
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw SubTitlesError.invalidEncoding
+        }
+        return content
+    }
+}
+
+public extension Subtitles.Coder.JSONPodcastIndex {
+    /// Decode subtitles from json data
+    /// - Parameters:
+    ///   - data: The data to decode
+    ///   - encoding: The string encoding for the data content
+    /// - Returns: Subtitles
+    func decode(_ data: Data, encoding: String.Encoding) throws -> Subtitles {
+        let value =  try JSONDecoder().decode(Subtitles.Coder.JSONPodcastIndex.self, from: data)
+        var cues = [Subtitles.Cue]()
+        for segment in value.segments {
+            cues.append(Subtitles.Cue(startTime: Subtitles.Time(timeInSeconds: segment.startTime), duration: segment.endTime - segment.startTime, text: segment.body))
+        }
+        return Subtitles(cues)
+    }
+
+    /// Decode subtitles from a json string
+    /// - Parameters:
+    ///   - content: The string
+    /// - Returns: Subtitles
+    func decode(_ content: String) throws -> Subtitles {
+        guard let data = content.data(using: .utf8) else {
+            throw SubTitlesError.invalidEncoding
+        }
+        return try self.decode(data, encoding: .utf8)
+    }
+}

--- a/Tests/SwiftSubtitlesTests/JSONPodcastIndexTests.swift
+++ b/Tests/SwiftSubtitlesTests/JSONPodcastIndexTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import SwiftSubtitles
+
+final class JSONPodcastIndexTests: XCTestCase {
+    func testExample() throws {
+        let fileURL = Bundle.module.url(forResource: "sample", withExtension: "json")!
+        let subtitles = try Subtitles(fileURL: fileURL, encoding: .utf8)
+        XCTAssertEqual(3, subtitles.cues.count)
+        XCTAssertEqual(Subtitles.Time(timeInSeconds: 2.15), subtitles.cues[0].startTime)
+        XCTAssertEqual(Subtitles.Time(timeInSeconds: 2.20), subtitles.cues[0].endTime)
+        XCTAssertEqual("This video was recorded and uploaded to Youtube.", subtitles.cues[0].text)
+
+        XCTAssertEqual(Subtitles.Time(timeInSeconds: 2.25), subtitles.cues[2].startTime)
+        XCTAssertEqual(Subtitles.Time(timeInSeconds: 2.30), subtitles.cues[2].endTime)
+        XCTAssertEqual("I converted the captions from another file.", subtitles.cues[2].text)
+
+        let coder = Subtitles.Coder.VTT()
+        let encoded = try coder.encode(subtitles: subtitles)
+        let decoded = try coder.decode(encoded)
+        XCTAssertEqual(3, decoded.cues.count)
+    }
+}

--- a/Tests/SwiftSubtitlesTests/resources/json/sample.json
+++ b/Tests/SwiftSubtitlesTests/resources/json/sample.json
@@ -17,7 +17,7 @@
             "speaker": "Peter",
             "startTime": 2.25,
             "endTime": 2.30,
-            "body":  "I converted the captions from another file."
+            "body": "I converted the captions from another file."
         }
     ]
 }

--- a/Tests/SwiftSubtitlesTests/resources/json/sample.json
+++ b/Tests/SwiftSubtitlesTests/resources/json/sample.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.0.0",
+    "segments": [
+        {
+            "speaker": "Peter",
+            "startTime": 2.15,
+            "endTime": 2.20,
+            "body": "This video was recorded and uploaded to Youtube."
+        },
+        {
+            "speaker": null,
+            "startTime": 2.20,
+            "endTime": 2.25,
+            "body": "Then, after the video had been processed and had captions auto-generated for it by Youtube!"
+        },
+        {
+            "speaker": "Peter",
+            "startTime": 2.25,
+            "endTime": 2.30,
+            "body":  "I converted the captions from another file."
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds support for [Podcast Index Transcript JSON format](https://github.com/Podcastindex-org/podcast-namespace/blob/main/transcripts/transcripts.md#json)

This format is supported for some podcasts that are in [Podcast Index  Org](https://podcastindex.org)

One open question for me is that SwiftSubtitles has any plan to support an explicit attribute on Cue for the speaker information.