### PR TITLE
Add fix to avoid crash when parsing empty files.

### DIFF
--- a/Sources/SwiftSubtitles/coding/VTT.swift
+++ b/Sources/SwiftSubtitles/coding/VTT.swift
@@ -125,7 +125,7 @@ public extension Subtitles.Coder.VTT {
 			.enumerated()
 			.map { (offset: $0.offset, element: $0.element) }
 
-		guard lines[0].element.contains("WEBVTT") else {
+        guard let firstLine = lines.first, firstLine.element.contains("WEBVTT") else {
 			throw SubTitlesError.invalidFile
 		}
 

--- a/Tests/SwiftSubtitlesTests/VTTTests.swift
+++ b/Tests/SwiftSubtitlesTests/VTTTests.swift
@@ -2,29 +2,29 @@ import XCTest
 @testable import SwiftSubtitles
 
 final class VTTTests: XCTestCase {
-	func testExample() throws {
-		let fileURL = Bundle.module.url(forResource: "sample", withExtension: "vtt")!
-		let subtitles = try Subtitles(fileURL: fileURL, encoding: .utf8)
-		XCTAssertEqual(3, subtitles.cues.count)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 15, millisecond: 0), subtitles.cues[0].startTime)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 20, millisecond: 0), subtitles.cues[0].endTime)
-		XCTAssertEqual("- Ta en kopp varmt te.\n- Det är inte varmt.", subtitles.cues[0].text)
+    func testExample() throws {
+        let fileURL = Bundle.module.url(forResource: "sample", withExtension: "vtt")!
+        let subtitles = try Subtitles(fileURL: fileURL, encoding: .utf8)
+        XCTAssertEqual(3, subtitles.cues.count)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 15, millisecond: 0), subtitles.cues[0].startTime)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 20, millisecond: 0), subtitles.cues[0].endTime)
+        XCTAssertEqual("- Ta en kopp varmt te.\n- Det är inte varmt.", subtitles.cues[0].text)
 
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 25, millisecond: 0), subtitles.cues[2].startTime)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 30, millisecond: 0), subtitles.cues[2].endTime)
-		XCTAssertEqual("3 This is the third chapter", subtitles.cues[2].identifier)
-		XCTAssertEqual("- Ta en kopp", subtitles.cues[2].text)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 25, millisecond: 0), subtitles.cues[2].startTime)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 2, second: 30, millisecond: 0), subtitles.cues[2].endTime)
+        XCTAssertEqual("3 This is the third chapter", subtitles.cues[2].identifier)
+        XCTAssertEqual("- Ta en kopp", subtitles.cues[2].text)
 
-		let coder = Subtitles.Coder.VTT()
-		let encoded = try coder.encode(subtitles: subtitles)
-		let decoded = try coder.decode(encoded)
-		XCTAssertEqual(3, decoded.cues.count)
+        let coder = Subtitles.Coder.VTT()
+        let encoded = try coder.encode(subtitles: subtitles)
+        let decoded = try coder.decode(encoded)
+        XCTAssertEqual(3, decoded.cues.count)
 
-		XCTAssertEqual(subtitles, decoded)
-	}
+        XCTAssertEqual(subtitles, decoded)
+    }
 
-	func testDecode() throws {
-		let vtt = """
+    func testDecode() throws {
+        let vtt = """
 WEBVTT
 
 00:01.000 --> 00:04.000
@@ -34,29 +34,36 @@ WEBVTT
 - It will perforate your stomach.
 - You could die.
 """
-		let coder = Subtitles.Coder.VTT()
-		let subtitles = try coder.decode(vtt)
-		XCTAssertEqual(2, subtitles.cues.count)
-		XCTAssertEqual("- Never drink liquid nitrogen.", subtitles.cues[0].text)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0), subtitles.cues[0].startTime)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0), subtitles.cues[0].endTime)
+        let coder = Subtitles.Coder.VTT()
+        let subtitles = try coder.decode(vtt)
+        XCTAssertEqual(2, subtitles.cues.count)
+        XCTAssertEqual("- Never drink liquid nitrogen.", subtitles.cues[0].text)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0), subtitles.cues[0].startTime)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0), subtitles.cues[0].endTime)
 
-		XCTAssertEqual("- It will perforate your stomach.\n- You could die.", subtitles.cues[1].text)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 5, millisecond: 0), subtitles.cues[1].startTime)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 9, millisecond: 0), subtitles.cues[1].endTime)
+        XCTAssertEqual("- It will perforate your stomach.\n- You could die.", subtitles.cues[1].text)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 5, millisecond: 0), subtitles.cues[1].startTime)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 9, millisecond: 0), subtitles.cues[1].endTime)
 
-		let encoded = try coder.encode(subtitles: subtitles)
-		let decoded = try coder.decode(encoded)
-		XCTAssertEqual(2, decoded.cues.count)
+        let encoded = try coder.encode(subtitles: subtitles)
+        let decoded = try coder.decode(encoded)
+        XCTAssertEqual(2, decoded.cues.count)
 
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0), subtitles.cues[0].startTime)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0), subtitles.cues[0].endTime)
-		XCTAssertEqual("- Never drink liquid nitrogen.", decoded.cues[0].text)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 1, millisecond: 0), subtitles.cues[0].startTime)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 4, millisecond: 0), subtitles.cues[0].endTime)
+        XCTAssertEqual("- Never drink liquid nitrogen.", decoded.cues[0].text)
 
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 5, millisecond: 0), subtitles.cues[1].startTime)
-		XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 9, millisecond: 0), subtitles.cues[1].endTime)
-		XCTAssertEqual("- It will perforate your stomach.\n- You could die.", decoded.cues[1].text)
-	}
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 5, millisecond: 0), subtitles.cues[1].startTime)
+        XCTAssertEqual(Subtitles.Time(hour: 0, minute: 0, second: 9, millisecond: 0), subtitles.cues[1].endTime)
+        XCTAssertEqual("- It will perforate your stomach.\n- You could die.", decoded.cues[1].text)
+    }
+
+    func testEmptyDecode() throws {
+        let vtt = """
+            """
+        let coder = Subtitles.Coder.VTT()
+        XCTAssertThrowsError(try coder.decode(vtt))
+    }
 
 	func testMicrosoftTests() throws {
 		// https://support.microsoft.com/en-us/office/create-closed-captions-for-a-video-b1cfb30f-5b00-4435-beeb-2a25e115024b


### PR DESCRIPTION
I've run into the issue that the library was crashing when opening an empty file.

This PR ads a fix to check if the lines are completely empty before checking the first line for the VTT file signature.